### PR TITLE
Fix OG image base URL to use correct production domain

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ const notoSansJp = Noto_Sans_JP({
 });
 
 const getBaseUrl = () => {
-  if (process.env.VERCEL_ENV === 'production') return 'https://ten-hou.com';
+  if (process.env.VERCEL_ENV === 'production') return 'https://portfolio.ten-hou.com';
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
   return 'http://localhost:3000';
 };


### PR DESCRIPTION
## Summary
- `getBaseUrl()` で本番ドメインが `https://ten-hou.com` に誤設定されていたため、OG画像URLが壊れていた
- 正しいドメイン `https://portfolio.ten-hou.com` に修正

## Test plan
- [ ] デプロイ後に `https://portfolio.ten-hou.com/tenhouPortfolioIcon.png` へアクセスして画像が表示されることを確認
- [ ] Discordにリンクを貼ってプレビュー画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)