### PR TITLE
Twitter/XリンクをSpeaker Deckに変更

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -53,7 +53,7 @@ function buildSystemPrompt(): string {
 - 最近のマイブームはキーボード設計
 - GDG（Google Developer Groups）のコミュニティ活動に積極的に参加・運営している
 - 連絡先: トップページにある「Contact me」ボタンを押すと/contactページに移動し、埋め込まれたフォームからメッセージを送れる
-- SNS・各種リンク: トップページにある「LinkedIn」「GitHub」「X（旧Twitter）」ボタンからそれぞれのプロフィールへアクセスできる
+- SNS・各種リンク: トップページにある「LinkedIn」「GitHub」「Speaker Deck」ボタンからそれぞれのプロフィールへアクセスできる
 - 英語名: Ayato Fujita
 - 肩書き: Software / Hardware Engineer、Product Manager
 - キャッチコピー: "Do it with ease, without noise, and with elegance."

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -2,8 +2,8 @@ export default function Footer() {
   return (
     <footer className="neo-footer">
       <div className="neo-footer__links">
-        <a href="https://x.com/tenhou_0126" target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)">
-          X
+        <a href="https://speakerdeck.com/tenhou" target="_blank" rel="noopener noreferrer" aria-label="Speaker Deck">
+          SPEAKER DECK
         </a>
         <a href="https://github.com/tenhou-Ravenclaw" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
           GITHUB

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -67,10 +67,10 @@ const accountLinks: AccountLink[] = [
     external: true,
   },
   {
-    label: "X",
-    href: "https://x.com/tenhou_0126",
-    caption: "@tenhou_0126",
-    faviconDomain: "x.com",
+    label: "Speaker Deck",
+    href: "https://speakerdeck.com/tenhou",
+    caption: "tenhou",
+    faviconDomain: "speakerdeck.com",
     external: true,
   },
   {


### PR DESCRIPTION
## Summary
- Footer、HeroSectionのアイコンリンクをX(Twitter)からSpeaker Deckに変更
- チャットボットのシステムプロンプト内の説明文も合わせて更新

## Test plan
- [x] `npx tsc --noEmit` でエラーがないことを確認
- [x] ローカル (`npm run dev`) でFooterとHeroSectionにSpeaker Deckリンクが表示されることを確認